### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 language: node_js
 
 node_js:
-  - 10/*
+  - 10.17.0
 
 sudo: required
 


### PR DESCRIPTION
There is a know issue with Travis CI build failing, setting node version to `10.17.0` should fix this issue.